### PR TITLE
Print to console for JavaScript

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,5 +1,5 @@
 function! s:DebugStringFun()
-    let l:debug_str = '<script>alert( ' . g:DebugstringPrefixStr()  . g:debugStringCounter . '); </script>'
+    let l:debug_str = 'console.log("' . g:DebugstringPrefixStr()  . g:debugStringCounter . '");'
     :return l:debug_str
 endfunc
 


### PR DESCRIPTION
Current behavior injects
```js
<script>alert( [hello.js:168] DEBUGGING STRING ==> 0); </script>
```
This will not  work due to:
* having a tag in the middle of code fails with syntax error
* debug string has to be escaped with quotes
* `alert()` is a browser methods. `console.log()` is more universal.

This PR will produce instead
```js
 console.log("[hello.js:168] DEBUGGING STRING ==> 0");
```
