### PR TITLE
README: fix typo in clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ please raise an
 
 ```bash
 git clone https://github.com/tpope/vim-repeat ~/.vim/bundle/vim-repeat
-git clone https://github.com/bergercookie/vim-debustring.git ~/.vim/bundle/vim-debugstring
+git clone https://github.com/bergercookie/vim-debugstring.git ~/.vim/bundle/vim-debugstring
 
 ```
 


### PR DESCRIPTION
there's a minor typo in README. I find it just because I want to quick test this plugin by copy-n-paste the instruction