### PR TITLE
Fix js variable debugging for complex variables

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -4,7 +4,7 @@ function! s:DebugStringFun()
 endfunc
 
 function! s:DebugVarFun(desc, var)
-    let l:debug_str = 'console.log(`' . a:desc . '${' . a:var . '}`)'
+    let l:debug_str = 'console.log(`' . a:desc . '`, ' . a:var . ')'
     return l:debug_str
 endfunc
 


### PR DESCRIPTION
Hey @bergercookie, I couldn't find info on how to create a PR, so I hope this is ok.
When debugging with string interpolation it would work for basic types, like:
```javascript
> const a = 'some string';
undefined
> console.log(`a: ${a}`)
a: some text
undefined
```
But if you try to print an object/array, you get:
```javascript
> const b = {foo: 'bar', baz: ['h', 'a', 'm']}
undefined
> console.log(`b: ${b}`)
b: [object Object]
undefined
```
To solve this we could either stringify it, or we could pass the var as another arg, which allows for inspecting it when on browser:
```javascript
> const b = {foo: 'bar', baz: ['h', 'a', 'm']}
undefined
> console.log(`b: `, b)
b:  { foo: 'bar', baz: [ 'h', 'a', 'm' ] }
undefined
```