### PR TITLE
Add support for Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ D            | :x:                | :x:
 Dockerfile   | :heavy_check_mark: | :heavy_check_mark:
 Fish-Shell   | :heavy_check_mark: | :heavy_check_mark:
 Fortran      | :heavy_check_mark: | :heavy_check_mark:
-Go           | :x:                | :x:
+Go           | :heavy_check_mark: | :heavy_check_mark:
 Haskell      | :heavy_check_mark: | :heavy_check_mark:
 Java         | :heavy_check_mark: | :heavy_check_mark:
 Javascript   | :heavy_check_mark: | :heavy_check_mark:

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -1,0 +1,9 @@
+function! s:DebugStringFunBase(desc, var)
+    let l:debug_str = "fmt.Printf(\"" . a:desc . "%+v\\n\", " . a:var . ")"
+    return l:debug_str
+endfunc
+
+command! -buffer -nargs=0 AddDebugString
+            \ put=s:DebugStringFunBase(g:DebugstringPrefixStr(), g:debugStringCounter)
+command! -buffer -nargs=1 AddDebugStringExpr
+            \ put=s:DebugStringFunBase(<args> . ': ', <args>)

--- a/test/basic.vader
+++ b/test/basic.vader
@@ -62,6 +62,8 @@ Execute (Vim):
   :set filetype=vim
 Execute (Fortran):
   :set filetype=fortran
+Execute (Go):
+  :set filetype=go
 Execute (Arduino):
   :set filetype=arduino
 Execute (Makefile):

--- a/test/ft/a.go
+++ b/test/ft/a.go
@@ -1,0 +1,2 @@
+fmt.Printf("[[Vader-workbench]:$1$] DEBUGGING STRING ==> %+v\n", $2$)
+fmt.Printf("a**2 + b**2: %+v\n", a**2 + b**2)


### PR DESCRIPTION
Note that this requires `import "fmt"` but https://github.com/fatih/vim-go features auto import so it will get added automatically for anyone using that.

Also to explain `%+v`, `v` is a default format that works generically and `+` adds struct field names; see https://golang.org/pkg/fmt/ and https://stackoverflow.com/a/24512194/7078832.

Thanks for the great plugin.