### PR TITLE
Fix lua boolean errors by wrapping tostring

### DIFF
--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -1,5 +1,5 @@
 function! s:DebugStringFunBase(desc, var)
-    let l:debug_str = 'print("' . a:desc . '" .. ' . a:var . ')'
+    let l:debug_str = 'print("' . a:desc . '" .. tostring(' . a:var . '))'
     return l:debug_str
 endfunc
 

--- a/test/ft/a.lua
+++ b/test/ft/a.lua
@@ -1,2 +1,2 @@
-print("[[Vader-workbench]:$1$] DEBUGGING STRING ==> " .. $2$)
-print("a**2 + b**2: " .. a**2 + b**2)
+print("[[Vader-workbench]:$1$] DEBUGGING STRING ==> " .. tostring($2$))
+print("a**2 + b**2: " .. tostring(a**2 + b**2))


### PR DESCRIPTION
lua errors if you call print with a boolean: `...lua:48: attempt to concatenate local 'result' (a boolean value)`.

To avoid such errors, wrap the printed variable with `tostring` – see https://stackoverflow.com/questions/6615572/how-to-format-a-lua-string-with-a-boolean-variable

